### PR TITLE
Fix crash when replacing 9patch asset in a project

### DIFF
--- a/src/main/java/games/rednblack/editor/renderer/factory/component/NinePatchComponentFactory.java
+++ b/src/main/java/games/rednblack/editor/renderer/factory/component/NinePatchComponentFactory.java
@@ -52,6 +52,9 @@ public class NinePatchComponentFactory extends ComponentFactory {
 		NinePatchComponent ninePatchComponent = engine.createComponent(NinePatchComponent.class);
 		AtlasRegion atlasRegion = (AtlasRegion) rm.getTextureRegion(vo.imageName);
 		int[] splits = atlasRegion.findValue("split");
+		if (splits == null) {
+			splits = new int[]{0, 0, 0, 0};
+		}
 		ninePatchComponent.ninePatch = new NinePatch(atlasRegion, splits[0], splits[1], splits[2], splits[3]);
 
 		ResolutionEntryVO resolutionEntryVO = rm.getLoadedResolution();


### PR DESCRIPTION
I ran into this issue when replacing a ninepatch asset in my project. If a 9patch asset is deleted from the project, and then a new asset with the same name is added Hyperlap2D will crash. This crash continues to occur if the project is opened back up. I've added a quick fix to init the splits array if a scene is loaded that contains 9patch asset data, but that asset is no longer a 9patch in the project atlas.